### PR TITLE
Update preset-clash-core.sh

### DIFF
--- a/scripts/preset-clash-core.sh
+++ b/scripts/preset-clash-core.sh
@@ -11,9 +11,20 @@
 
 mkdir -p files/etc/openclash/core
 
-CLASH_DEV_URL="https://raw.githubusercontent.com/vernesong/OpenClash/master/core-lateset/dev/clash-linux-${1}.tar.gz"
-CLASH_TUN_URL=$(curl -fsSL https://api.github.com/repos/vernesong/OpenClash/contents/core-lateset/premium | grep download_url | grep $1 | awk -F '"' '{print $4}')
-CLASH_META_URL="https://raw.githubusercontent.com/vernesong/OpenClash/master/core-lateset/meta/clash-linux-${1}.tar.gz"
+
+
+
+# openclash 的 dev内核
+CLASH_DEV_URL="https://github.com/vernesong/OpenClash/raw/core/master/dev/clash-linux-${1}.tar.gz"
+# openclash 的 TUN内核
+CLASH_TUN_VERSION=$(curl -sL https://github.com/vernesong/OpenClash/raw/core/master/core_version | head -n 2 | tail -n 1)
+CLASH_TUN_URL="https://github.com/vernesong/OpenClash/raw/core/master/premium/clash-linux-${1}-$CLASH_TUN_VERSION.gz"
+# openclash 的 Meta内核版本
+CLASH_META_URL="https://github.com/vernesong/OpenClash/raw/core/master/meta/clash-linux-${1}.tar.gz"
+
+# CLASH_DEV_URL="https://raw.githubusercontent.com/vernesong/OpenClash/master/core-lateset/dev/clash-linux-${1}.tar.gz"
+# CLASH_TUN_URL=$(curl -fsSL https://api.github.com/repos/vernesong/OpenClash/contents/core-lateset/premium | grep download_url | grep $1 | awk -F '"' '{print $4}')
+# CLASH_META_URL="https://raw.githubusercontent.com/vernesong/OpenClash/master/core-lateset/meta/clash-linux-${1}.tar.gz"
 GEOIP_URL="https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geoip.dat"
 GEOSITE_URL="https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download/geosite.dat"
 


### PR DESCRIPTION
openclash 内核下载位置发生变化，内核地址 https://github.com/vernesong/OpenClash/tree/core/master issue也不开，只能pr了，还没来得及测试